### PR TITLE
Compilation Fix for Raytracer

### DIFF
--- a/COMP371_RaytracerBase/code/CMakeLists.txt
+++ b/COMP371_RaytracerBase/code/CMakeLists.txt
@@ -1,8 +1,6 @@
-
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(raytracer) 
-
 
 #IMPORTANT COMPILING DIRECTIVES
 
@@ -18,26 +16,13 @@ project(raytracer)
 # This define is used by the teaching team to compile and run the official solution
 # Students: for your project this define should always be commented out
 # If we commit it by mistake please disable it and let us know
-add_compile_options(-DCOURSE_SOLUTION)
+#add_compile_options(-DCOURSE_SOLUTION)
 
 
 set(CMAKE_CXX_STANDARD 14)
 
-
 find_package(Eigen3 REQUIRED)
-include_directories(EIGEN3_INCLUDE_DIR)
-include_directories(${Eigen3_INCLUDE_DIRS})
-link_directories(${Eigen3_INCLUDE_DIRS})
-
-# not sure why on my machine the above options don't work
-# I need to add it manually here
-include_directories(/opt/local/include/)
-include_directories(/opt/local/include/eigen3/)
-
-#Additions for the lab
-include_directories(/encs/include/)
-include_directories(/encs/pkg/eigen-3.3.7/root/)
-link_directories(/encs/lib64/)
+include_directories(${EIGEN3_INCLUDE_DIRS})
 
 # If you need too manually add the paths to your Eigen library, you can add it here
 # do not delete the other 
@@ -48,11 +33,5 @@ include_directories(external/)
 aux_source_directory(external SOURCE)
 aux_source_directory(src SOURCE)
 
-
 add_executable(raytracer main.cpp ${SOURCE}) #The name of the cpp file and its path can vary
 
-# link only to Eigen
-target_link_libraries(${PROJECT_NAME}
-#   ${Eigen3_LIBRARIES}
-#/encs/pkg/eigen-3.3.7/root
-   )


### PR DESCRIPTION
Fixed Eigen3 include variables and removed -DCOURSE_SOLUTION for
compilation.

Please test on macOS and Windows.