### PR TITLE
CMake Update

### DIFF
--- a/COMP371_RaytracerBase/code/CMakeLists.txt
+++ b/COMP371_RaytracerBase/code/CMakeLists.txt
@@ -18,18 +18,26 @@ project(raytracer)
 # If we commit it by mistake please disable it and let us know
 #add_compile_options(-DCOURSE_SOLUTION)
 
+set(CMAKE_BUILD_TYPE Debug)
 
 set(CMAKE_CXX_STANDARD 14)
 
+set(CMAKE_PREFIX_PATH
+    /encs # For ENCS lab computers
+    /opt/local # Macports
+)
+
+# ENCS Eigen3 CMake setup
+set(ENV{EIGEN3_ROOT} /encs/pkg/eigen-3.3.7/root)
+set(CMAKE_MODULE_PATH /encs/pkg/eigen-3.3.7/root/cmake)
+
 find_package(Eigen3 REQUIRED)
-include_directories(${EIGEN3_INCLUDE_DIRS})
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 # If you need too manually add the paths to your Eigen library, you can add it here
 # do not delete the other 
 
 #internal includes
-include_directories(src/)
-include_directories(external/)
 aux_source_directory(external SOURCE)
 aux_source_directory(src SOURCE)
 

--- a/Lab_capsules/capsule1/code/CMakeLists.txt
+++ b/Lab_capsules/capsule1/code/CMakeLists.txt
@@ -1,17 +1,25 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(capsule01) #The name of your choice for the project comes here
+project(capsule01) # The name of your choice for the project comes here
 
-find_package(OpenGL REQUIRED COMPONENTS OpenGL)
-find_package(glfw3 REQUIRED)
-find_package(glew REQUIRED)
+set(CMAKE_BUILD_TYPE Debug)
 
 set(CMAKE_CXX_STANDARD 11)
 
-link_directories(/opt/local/lib/)
+set(CMAKE_PREFIX_PATH
+    /encs # For ENCS lab computers
+    /opt/local # Macports
+)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPLATFORM_OSX")
+find_package(OpenGL REQUIRED COMPONENTS OpenGL)
+find_package(GLEW REQUIRED)
+find_package(glfw3 REQUIRED
+    HINTS /encs/pkg/glfw-3.3.4/root # ENCS installation of glfw
+)
+
+# NOTE: ENCS glm installation is missing links to *.inl files so we need this line
+include_directories(/encs/pkg/glm-0.9.9.8/root/include)
 
 add_executable(${PROJECT_NAME} capsule01.cpp) #The name of the cpp file and its path can vary
 
-target_link_libraries(${PROJECT_NAME} OpenGL::GL glew glfw)
+target_link_libraries(${PROJECT_NAME} OpenGL::GL GLEW::glew glfw)

--- a/Lab_capsules/capsule1/code/capsule01.cpp
+++ b/Lab_capsules/capsule1/code/capsule01.cpp
@@ -160,17 +160,10 @@ int main(int argc, char*argv[])
     // Initialize GLFW and OpenGL version
     glfwInit();
 
-#if defined(PLATFORM_OSX)
-    std::cout<<"MAC"<<std::endl;
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3); 
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2); 
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3); 
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-#else
-	// We support only Linux
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-#endif
 
     // Create Window and rendering context using GLFW, resolution is 800x600
     GLFWwindow* window = glfwCreateWindow(800, 600, "Comp371 - Lab 01", NULL, NULL);

--- a/Lab_capsules/capsule2/code/CMakeLists.txt
+++ b/Lab_capsules/capsule2/code/CMakeLists.txt
@@ -1,18 +1,25 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(capsule02) #The name of your choice for the project comes here
+project(capsule02) # The name of your choice for the project comes here
 
-find_package(OpenGL REQUIRED COMPONENTS OpenGL)
-find_package(glfw3 REQUIRED)
-find_package(GLEW REQUIRED)
-
+set(CMAKE_BUILD_TYPE Debug)
 
 set(CMAKE_CXX_STANDARD 11)
 
-link_directories(/opt/local/lib/)
+set(CMAKE_PREFIX_PATH
+    /encs # For ENCS lab computers
+    /opt/local # Macports
+)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPLATFORM_OSX")
+find_package(OpenGL REQUIRED COMPONENTS OpenGL)
+find_package(GLEW REQUIRED)
+find_package(glfw3 REQUIRED
+    HINTS /encs/pkg/glfw-3.3.4/root # ENCS installation of glfw
+)
 
-add_executable(${PROJECT_NAME}  capsule02.cpp) #The name of the cpp file and its path can vary
+# NOTE: ENCS glm installation is missing links to *.inl files so we need this line
+include_directories(/encs/pkg/glm-0.9.9.8/root/include)
 
-target_link_libraries(${PROJECT_NAME} OpenGL::GL glew glfw)
+add_executable(${PROJECT_NAME} capsule02.cpp) #The name of the cpp file and its path can vary
+
+target_link_libraries(${PROJECT_NAME} OpenGL::GL GLEW::glew glfw)

--- a/Lab_capsules/capsule2/code/capsule02.cpp
+++ b/Lab_capsules/capsule2/code/capsule02.cpp
@@ -261,17 +261,10 @@ int main(int argc, char*argv[])
     // Initialize GLFW and OpenGL version
     glfwInit();
 
-#if defined(PLATFORM_OSX)
-    std::cout<<"MAC"<<std::endl;
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3); 
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2); 
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3); 
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-#else
-	// We support only Linux
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-#endif
 
     // Create Window and rendering context using GLFW, resolution is 800x600
     GLFWwindow* window = glfwCreateWindow(800, 600, "Comp371 - Lab 01", NULL, NULL);

--- a/Lab_capsules/capsule3/CMakeLists.txt
+++ b/Lab_capsules/capsule3/CMakeLists.txt
@@ -1,19 +1,26 @@
-
 cmake_minimum_required (VERSION 3.8)
+
 project(capsule03)
 
+set(CMAKE_BUILD_TYPE Debug)
 
 set(CMAKE_CXX_STANDARD 11) #optional to use c++11
 
+set(CMAKE_PREFIX_PATH
+    /encs # For ENCS lab computers
+    /opt/local # Macports
+)
+
 find_package(OpenGL REQUIRED COMPONENTS OpenGL)
 find_package(GLEW REQUIRED)
-find_package(glfw3 REQUIRED)
-find_package(glm REQUIRED)
+find_package(glfw3 REQUIRED
+    HINTS /encs/pkg/glfw-3.3.4/root # ENCS installation of glfw
+)
 
 set(ALL_LIBS
 	OpenGL::GL
 	OpenGL::GLU
-	GLEW
+	GLEW::glew
 	glfw
 ) 
 
@@ -27,9 +34,8 @@ add_definitions(
 	-DUSE_ZLIB_T
 )
 
-
-link_directories(/opt/local/lib/)
-
+# NOTE: ENCS glm installation is missing links to *.inl files so we need this line
+include_directories(/encs/pkg/glm-0.9.9.8/root/include)
 
 aux_source_directory(src SOURCES)
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/Lab_capsules/capsule3/src/TOGLWindow.cpp
+++ b/Lab_capsules/capsule3/src/TOGLWindow.cpp
@@ -20,12 +20,13 @@ namespace TAPP {
         glfwWindowHint(GLFW_SAMPLES, 4);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE); // To make MacOS happy; should not be needed
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
         // Open a window and create its OpenGL context
         m_window = glfwCreateWindow(m_width, m_height, name.c_str(), NULL, NULL);
         if (m_window == NULL) {
-            fprintf(stderr, "Failed to open GLFW window. If you have an Intel GPU, they are not 3.3 compatible. Try the 2.1 version of the tutorials.\n");
+            fprintf(stderr, "Failed to open GLFW window. Please check if your video driver is installed correctly and if it is OpenGL 3.3+.\n");
             return false;
         }
         


### PR DESCRIPTION
I updated the CMake files so that they should work on macOS and the ENCS Lab computers so that they shouldn't require any switches.

I also removed the prepocessor directives for the OpenGL version hints since 3.3 has been ubiquitous since 2010.